### PR TITLE
Add .downcase to correct? to normalize answers

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -7,7 +7,7 @@ class Turn
   end
 
   def correct?
-    @guess == @card.answer
+    @guess.downcase == @card.answer.downcase
   end
 
   def feedback

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -31,6 +31,10 @@ class TurnTest < Minitest::Test
   def test_correct
     refute @turn.correct?
     assert @turn_2.correct?
+    new_turn = Turn.new("i don't know", @card)
+    assert new_turn.correct?
+    new_turn_2 = Turn.new("I DON't KnoW", @card)
+    assert new_turn_2.correct?
   end
 
   def test_feedback


### PR DESCRIPTION
The method .correct? in Turn class now downcases the guess and answer so that user guess does not have to match capitalization, just spelling.